### PR TITLE
Implement ESMpy mask handling

### DIFF
--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -119,10 +119,12 @@ def esmf_grid(lon, lat, periodic=False, mask=None):
     # See https://github.com/NCPP/ocgis/blob/61d88c60e9070215f28c1317221c2e074f8fb145/src/ocgis/regrid/base.py#L391-L404
     if mask is not None:
         grid_mask = np.swapaxes(mask.astype(np.int32), 0, 1)
+        grid_mask = np.where(grid_mask == 0, 0, 1)
         if not (grid_mask.shape == lon.shape):
-            raise ValueError("mask must have the same shape as the "
-                             "latitude/longitude coordinates, got:"
-                             "mask.shape = %s, lon.shape = %s" % (mask.shape, lon.shape))
+            raise ValueError(
+                "mask must have the same shape as the latitude/longitude"
+                "coordinates, got: mask.shape = %s, lon.shape = %s" %
+                (mask.shape, lon.shape))
         grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER,
                       from_file=False)
         grid.mask[0][:] = grid_mask

--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -256,7 +256,8 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
     # if the destination grid is larger than the source grid.
     regrid = ESMF.Regrid(sourcefield, destfield, filename=filename,
                          regrid_method=esmf_regrid_method,
-                         unmapped_action=ESMF.UnmappedAction.IGNORE)
+                         unmapped_action=ESMF.UnmappedAction.IGNORE,
+                         src_mask_values=[0], dst_mask_values=[0])
 
     return regrid
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -89,7 +89,7 @@ class Regridder(object):
             or 2D (Ny, Nx) for general curvilinear grids.
             Shape of bounds should be (N+1,) or (Ny+1, Nx+1).
 
-            If eiether dataset includes a 2d mask variable, that will also be
+            If either dataset includes a 2d mask variable, that will also be
             used to inform the regridding.
 
         method : str

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -54,8 +54,14 @@ def ds_to_ESMFgrid(ds, need_bounds=False, periodic=None, append=None):
     lat = np.asarray(ds['lat'])
     lon, lat = as_2d_mesh(lon, lat)
 
+    if 'mask' in ds:
+        mask = np.asarray(ds['mask'])
+        print(mask.shape)
+    else:
+        mask = None
+
     # tranpose the arrays so they become Fortran-ordered
-    grid = esmf_grid(lon.T, lat.T, periodic=periodic)
+    grid = esmf_grid(lon.T, lat.T, periodic=periodic, mask=mask)
 
     if need_bounds:
         lon_b = np.asarray(ds['lon_b'])
@@ -82,6 +88,9 @@ class Regridder(object):
             Shape can be 1D (Nlon,) and (Nlat,) for rectilinear grids,
             or 2D (Ny, Nx) for general curvilinear grids.
             Shape of bounds should be (N+1,) or (Ny+1, Nx+1).
+
+            If eiether dataset includes a 2d mask variable, that will also be
+            used to inform the regridding.
 
         method : str
             Regridding method. Options are

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -170,3 +170,20 @@ def test_regrid_with_1d_grid():
 
     # clean-up
     regridder.clean_weight_file()
+
+
+def test_build_regridder_with_masks():
+    ds_in['mask'] = xr.DataArray(
+        np.random.randint(2, size=ds_in['data'].shape),
+        dims=('y', 'x'))
+    print(ds_in)
+    # 'patch' is too slow to test
+    for method in ['bilinear', 'conservative', 'nearest_s2d', 'nearest_d2s']:
+        regridder = xe.Regridder(ds_in, ds_out, method)
+
+        # check screen output
+        assert repr(regridder) == str(regridder)
+        assert 'xESMF Regridder' in str(regridder)
+        assert method in str(regridder)
+
+        regridder.clean_weight_file()


### PR DESCRIPTION
This comes from the discussion in #22. It is intended to help users specify masks for the valid cells in the source and/or destination grids. It does this in the following way:

- looks for `mask` variable in `ds_in` and `ds_out`
- if `mask` variable is present, it adds that mask to the ESMF grid object
- specifies the mask values in the `ESMF.Regrid()` call. 

I've been testing this and it seems to be headed in the right direction. There are certainly additional features/tests/docs that this will need but I'm putting up here to aid in our discussion.
