### PR TITLE
Reduce number of steps to regrid

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -280,7 +280,7 @@ class Regridder(object):
         shape_horiz = indata.shape[-2:]  # the rightmost two dimensions
         assert shape_horiz == (self.Ny_in, self.Nx_in), (
              'The horizontal shape of input data is {}, different from that of'
-             'the regridder {}!'.format(shape_horiz, (self.Ny_in, self.Nx_in))
+             ' the regridder {}!'.format(shape_horiz, (self.Ny_in, self.Nx_in))
              )
 
         outdata = apply_weights(self.A, indata, self.Ny_out, self.Nx_out)

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -1,6 +1,10 @@
+import xesmf as xe
 import numpy as np
 import xarray as xr
 import warnings
+
+LON = 'lon'
+LAT = 'lat'
 
 
 def _grid_1d(start_b, end_b, step):
@@ -96,3 +100,115 @@ def grid_global(d_lon, d_lat):
                       'might not cover the globe uniformally'.format(d_lat))
 
     return grid_2d(-180, 180, d_lon, -90, 90, d_lat)
+
+
+def _regrid_it(da, d_lon, d_lat, **kwargs):
+    '''
+    Global 2D rectilinear grid centers and bounds
+
+    Parameters
+    ----------
+    da : xarray DataArray
+        Contain input and output grid coordinates. Look for variables
+        ``lon``, ``lat``, and optionally ``lon_b``, ``lat_b`` for
+        conservative method.
+
+        Shape can be 1D (Nlon,) and (Nlat,) for rectilinear grids,
+        or 2D (Ny, Nx) for general curvilinear grids.
+        Shape of bounds should be (N+1,) or (Ny+1, Nx+1).
+
+    d_lon : float
+        Longitude step size, i.e. grid resolution
+
+    d_lat : float
+        Latitude step size, i.e. grid resolution
+
+    Returns
+    -------
+    da : xarray DataArray with coordinate values
+
+    '''
+    try:
+        grid_out = {LON: np.arange(da[LON].min(), da[LON].max() + d_lon, d_lon),
+                    LAT: np.arange(da[LAT].min(), da[LAT].max() + d_lat, d_lat)}
+        regridder = xe.Regridder(da, grid_out, **kwargs)
+        return regridder(da)
+    except KeyError:
+        warnings.warn('Skipping {0} because it has no '
+                      'lon / lat coordinate'.format(da.name))
+        return da
+
+
+def regrid_it(ds, d_lon=1, d_lat=None, method='bilinear',
+              periodic=False, filename=None, reuse_weights=True):
+    '''
+    Quick regridding
+
+    Parameters
+    ----------
+    ds : xarray DataSet
+        Contain input and output grid coordinates. Look for variables
+        ``lon``, ``lat``, and optionally ``lon_b``, ``lat_b`` for
+        conservative method.
+
+        Shape can be 1D (Nlon,) and (Nlat,) for rectilinear grids,
+        or 2D (Ny, Nx) for general curvilinear grids.
+        Shape of bounds should be (N+1,) or (Ny+1, Nx+1).
+
+    d_lon : float, optional
+        Longitude step size, i.e. grid resolution; if not provided,
+        will equal 1
+
+    d_lat : float, optional
+        Latitude step size, i.e. grid resolution; if not provided,
+        will equal d_lon
+
+    method : str
+        Regridding method. Options are
+
+        - 'bilinear'
+        - 'conservative', **need grid corner information**
+        - 'patch'
+        - 'nearest_s2d'
+        - 'nearest_d2s'
+
+    periodic : bool, optional
+        Periodic in longitude? Default to False.
+        Only useful for global grids with non-conservative regridding.
+        Will be forced to False for conservative regridding.
+
+    filename : str, optional
+        Name for the weight file. The default naming scheme is::
+
+            {method}_{Ny_in}x{Nx_in}_{Ny_out}x{Nx_out}.nc
+
+        e.g. bilinear_400x600_300x400.nc
+
+    reuse_weights : bool, optional
+        Whether to read existing weight file to save computing time.
+        False by default (i.e. re-compute, not reuse).
+
+    Returns
+    -------
+    ds : xarray DataSet with coordinate values or DataArray
+
+    '''
+    if d_lat is None:
+        d_lat = d_lon
+
+    kwargs = {
+        'd_lon': d_lon,
+        'd_lat': d_lat,
+        'method': method,
+        'periodic':periodic,
+        'filename': filename,
+        'reuse_weights': reuse_weights,
+    }
+
+    if isinstance(ds, xr.Dataset):
+        ds = xr.merge(_regrid_it(ds[var], **kwargs)
+                      for var in ds.data_vars)
+    else:
+        ds = _regrid_it(ds, **kwargs)
+
+    return ds


### PR DESCRIPTION
Essentially creates
```
ds_out = xr.Dataset({'lat': (['lat'], np.arange(15, 75.01, 0.25)),
                     'lon': (['lon'], np.arange(200, 330.01, 0.5)),
                    }
                   )
```
on the go (finds the min/max of the lon/lat) and regrids; just pass in the ds and d_lon.

If d_lat is None, d_lat will be set to d_lon.

This also handles xr.datasets.

Must have 'lon' and 'lat' as coordinate.
If a variable does not have lon or lat, it'll raise a warning and skip, but keep it in the final dataset.

Test notebook: https://anaconda.org/ahuang11/test_xesmf_regrid_it