### PR TITLE
Adding 'latitude' and 'longitude' to acceptable coordinate names

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -20,8 +20,8 @@ def get_latlon_name(ds):
         lon_name = 'lon'
     # NETCDF CF 1.6 complaint 
       elif 'latitude' in ds.variables:
-        lat_name = 'lat'
-        lon_name = 'lon'
+        lat_name = 'latitude'
+        lon_name = 'longitude'
       else:
         raise ValueError
      except ValueError:


### PR DESCRIPTION
Adding 'latitude' and 'longitude' to acceptable coordinate names to be compliant with netCDF CF 1.6 conventions.  It adds a new method called get_latlon_names that checks if 'lat' or 'latitude' or netCDF COARDS convention or netCDF CF convention is in the xr.DataArray