### PR TITLE
minor syntax updates for Curvilinear_grid.ipynb

### DIFF
--- a/doc/Curvilinear_grid.ipynb
+++ b/doc/Curvilinear_grid.ipynb
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "ds = xr.tutorial.open_dataset('rasm').load()\n",
+    "ds = xr.tutorial.open_dataset('rasm') # use xr.tutorial.load_dataset() for xarray<v0.11.0\n",
     "ds"
    ]
   },

--- a/doc/Curvilinear_grid.ipynb
+++ b/doc/Curvilinear_grid.ipynb
@@ -81,7 +81,7 @@
     }
    ],
    "source": [
-    "ds = xr.tutorial.load_dataset('rasm')\n",
+    "ds = xr.tutorial.open_dataset('rasm').load()\n",
     "ds"
    ]
   },
@@ -261,7 +261,7 @@
     }
    ],
    "source": [
-    "ds.rename({'xc': 'lon', 'yc': 'lat'}, inplace=True)\n",
+    "ds = ds.rename({'xc': 'lon', 'yc': 'lat'})\n",
     "ds"
    ]
   },

--- a/doc/Rectilinear_grid.ipynb
+++ b/doc/Rectilinear_grid.ipynb
@@ -74,7 +74,7 @@
     }
    ],
    "source": [
-    "ds = xr.tutorial.load_dataset('air_temperature')\n",
+    "ds = xr.tutorial.open_dataset('air_temperature') # use xr.tutorial.load_dataset() for xarray<v0.11.0\n",
     "ds"
    ]
   },


### PR DESCRIPTION
cell 2: tutorial dataset loading syntax is updated;
cell 6: the `inplace` keyword is deprecated