### PR TITLE
Add option to allow degenerated grid cells

### DIFF
--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -157,7 +157,7 @@ def add_corner(grid, lon_b, lat_b):
 
 
 def esmf_regrid_build(sourcegrid, destgrid, method,
-                      filename=None, extra_dims=None):
+                      filename=None, extra_dims=None, ignore_degenerate=None):
     '''
     Create an ESMF.Regrid object, containing regridding weights.
 
@@ -194,6 +194,10 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
         i.e. following Fortran-like instead of C-like conventions.
         For example, if extra_dims=[Nlev, Ntime], then the data field dimension
         will be [Nlon, Nlat, Nlev, Ntime]
+
+    ignore_degenerate : bool, optional
+        If False (default), raise error if grids contain degenerated cells
+        (i.e. triangles or lines, instead of quadrilaterals)
 
     Returns
     -------
@@ -240,7 +244,8 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
     # if the destination grid is larger than the source grid.
     regrid = ESMF.Regrid(sourcefield, destfield, filename=filename,
                          regrid_method=esmf_regrid_method,
-                         unmapped_action=ESMF.UnmappedAction.IGNORE)
+                         unmapped_action=ESMF.UnmappedAction.IGNORE,
+                         ignore_degenerate=ignore_degenerate)
 
     return regrid
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -74,7 +74,7 @@ def ds_to_ESMFgrid(ds, need_bounds=False, periodic=None, append=None):
 
 class Regridder(object):
     def __init__(self, ds_in, ds_out, method, periodic=False,
-                 filename=None, reuse_weights=False):
+                 filename=None, reuse_weights=False, ignore_degenerate=None):
         """
         Make xESMF regridder
 
@@ -114,6 +114,10 @@ class Regridder(object):
             Whether to read existing weight file to save computing time.
             False by default (i.e. re-compute, not reuse).
 
+        ignore_degenerate : bool, optional
+            If False (default), raise error if grids contain degenerated cells
+            (i.e. triangles or lines, instead of quadrilaterals)
+
         Returns
         -------
         regridder : xESMF regridder object
@@ -130,6 +134,7 @@ class Regridder(object):
         self.method = method
         self.periodic = periodic
         self.reuse_weights = reuse_weights
+        self.ignore_degenerate = ignore_degenerate
 
         # construct ESMF grid, with some shape checking
         self._grid_in, shape_in = ds_to_ESMFgrid(ds_in,
@@ -217,7 +222,8 @@ class Regridder(object):
             print('Create weight file: {}'.format(self.filename))
 
         regrid = esmf_regrid_build(self._grid_in, self._grid_out, self.method,
-                                   filename=self.filename)
+                                   filename=self.filename,
+                                   ignore_degenerate=self.ignore_degenerate)
         esmf_regrid_finalize(regrid)  # only need weights, not regrid object
 
     def clean_weight_file(self):


### PR DESCRIPTION
Addresses #60 

By using `xe.Regridder(grid_in, grid_out, 'conservative', ignore_degenerate=True)`, ESMF won't throw an error when seeing degenerated cells like triangles. But it might give `nan` for such cells. Should probably still throw an error by default, as this helps detecting bad/illegal grid coordinates. Ref: https://github.com/JiaweiZhuang/xESMF/issues/22#issuecomment-403165146.

@bradyrx could you see whether this works properly for your problem?

TODO: 
- [ ] Add a test

Welcome to contribute test cases.