### PR TITLE
Added keep_attrs option for xarray regridding

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -253,7 +253,7 @@ class Regridder(object):
 
         return info
 
-    def __call__(self, indata, **kwargs):
+    def __call__(self, indata, keep_attrs=False):
         """
         Apply regridding to input data.
 
@@ -291,19 +291,17 @@ class Regridder(object):
         """
 
         if isinstance(indata, np.ndarray):
-            regrid_func = self.regrid_numpy
+            return self.regrid_numpy(indata)
         elif isinstance(indata, dask_array_type):
-            regrid_func = self.regrid_dask
+            return self.regrid_dask(indata)
         elif isinstance(indata, xr.DataArray):
-            regrid_func = self.regrid_dataarray
+            return self.regrid_dataarray(indata, keep_attrs=keep_attrs)
         elif isinstance(indata, xr.Dataset):
-            regrid_func = self.regrid_dataset
+            return self.regrid_dataset(indata, keep_attrs=keep_attrs)
         else:
             raise TypeError(
                 "input must be numpy array, dask array, "
                 "xarray DataArray or Dataset!")
-
-        return regrid_func(indata, **kwargs)
 
     def regrid_numpy(self, indata):
         """See __call__()."""

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -253,7 +253,7 @@ class Regridder(object):
 
         return info
 
-    def __call__(self, indata):
+    def __call__(self, indata, **kwargs):
         """
         Apply regridding to input data.
 
@@ -270,6 +270,10 @@ class Regridder(object):
 
             Transpose your input data if the horizontal dimensions are not
             the rightmost two dimensions.
+
+        keep_attrs : bool, optional
+            Keep attributes for xarray DataArrays or Datasets.
+            Defaults to False.
 
         Returns
         -------
@@ -299,7 +303,7 @@ class Regridder(object):
                 "input must be numpy array, dask array, "
                 "xarray DataArray or Dataset!")
 
-        return regrid_func(indata)
+        return regrid_func(indata, **kwargs)
 
     def regrid_numpy(self, indata):
         """See __call__()."""
@@ -324,7 +328,7 @@ class Regridder(object):
 
         return outdata
 
-    def regrid_dataarray(self, dr_in):
+    def regrid_dataarray(self, dr_in, keep_attrs=False):
         """See __call__()."""
 
         # example: ('lat', 'lon') or ('y', 'x')
@@ -343,7 +347,8 @@ class Regridder(object):
             output_dtypes=[float],
             output_sizes={temp_horiz_dims[0]: self.shape_out[0],
                           temp_horiz_dims[1]: self.shape_out[1]
-                          }
+                          },
+            keep_attrs=keep_attrs
         )
 
         # rename dimension name to match output grid
@@ -362,7 +367,7 @@ class Regridder(object):
 
         return dr_out
 
-    def regrid_dataset(self, ds_in):
+    def regrid_dataset(self, ds_in, keep_attrs=False):
         """See __call__()."""
 
         # most logic is the same as regrid_dataarray()
@@ -389,7 +394,8 @@ class Regridder(object):
             output_dtypes=[float],
             output_sizes={temp_horiz_dims[0]: self.shape_out[0],
                           temp_horiz_dims[1]: self.shape_out[1]
-                          }
+                          },
+            keep_attrs=keep_attrs
         )
 
         # rename dimension name to match output grid


### PR DESCRIPTION
As mentioned in #66 this pull request adds the option to keep the attributes of xarray objects after regridding. Because `__call__`  checks for the input datatype and selects different regrid functions, some of which are not xarray objects (and therefore keep_attrs would be meaningless), I implemented the arguments using `**kwargs`.

I realize this is not particularly nice, since the argument doesn't show up, e.g. when using autocomplete. The other option would be to do something like:
```python
if isinstance(indata, np.ndarray):
        return self.regrid_numpy(indata)
elif isinstance(indata, xr.DataArray):
        return regrid_dataarray(indata, keep_attrs=keep_attrs)
```
Would this be better?
