### PR TITLE
Add some CF support for lon and lat

### DIFF
--- a/xesmf/cf.py
+++ b/xesmf/cf.py
@@ -1,0 +1,143 @@
+"""
+Decode longitude and latitude of an `xarray.Dataset` or a `xarray.DataArray`
+according to CF conventions.
+"""
+
+import warnings
+
+CF_SPECS = {
+    'lon': {
+        'name': ['lon', 'longitude'],
+        'units': ['degrees_east', 'degree_east', 'degree_E', 'degrees_E',
+                  'degreeE', 'degreesE'],
+        'standard_name': ['longitude'],
+        'axis': 'X'
+        },
+    'lat': {
+        'name': ['lat', 'latitude'],
+        'units': ['degrees_north', 'degree_north', 'degree_N', 'degrees_N',
+                  'degreeN', 'degreesN'],
+        'standard_name': ['latitude'],
+        'axis': 'Y'
+        }
+    }
+
+
+
+def get_coord_name_from_specs(ds, specs):
+    '''
+    Get the name of a `xarray.DataArray` according to search specifications
+
+    Parameters
+    ----------
+    ds: xarray.DataArray or xarray.Dataset
+    specs: dict
+
+    Returns
+    -------
+    str: Name of the xarray.DataArray
+    '''
+    # Targets
+    ds_names = []
+    if hasattr(ds, 'coords'):
+        ds_names.extend(list(ds.coords))
+    if hasattr(ds, 'variables'):
+        ds_names.extend(list(ds.variables))
+
+    # Search in names first
+    if 'name' in specs:
+        for specs_name in specs['name']:
+            if specs_name in ds_names:
+                return specs_name
+
+    # Search in units attributes
+    if 'units' in specs:
+        for ds_name in ds_names:
+            if hasattr(ds[ds_name], 'units'):
+                for specs_units in specs['units']:
+                    if ds[ds_name].units == specs_units:
+                        return ds_name
+
+    # Search in standard_name attributes
+    if 'standard_name' in specs:
+        for ds_name in ds_names:
+            if hasattr(ds[ds_name], 'standard_name'):
+                for specs_sn in specs['standard_name']:
+                    if (ds[ds_name].standard_name == specs_sn or
+                            ds[ds_name].standard_name.startswith(
+                                specs_sn+'_at_')):
+                        return ds_name
+
+    # Search in axis attributes
+    if 'axis' in specs:
+        for ds_name in ds_names:
+            if (hasattr(ds[ds_name], 'axis') and
+                    ds[ds_name].axis.lower() == specs['axis'].lower()):
+                return ds_name
+
+
+def get_lon_name(ds):
+    '''
+    Get the longitude name in a `xarray.Dataset` or a `xarray.DataArray`
+
+    Parameters
+    ----------
+    ds: xarray.DataArray or xarray.Dataset
+
+    Returns
+    -------
+    str: Name of the xarray.DataArray
+    '''
+    lon_name = get_coord_name_from_specs(ds, CF_SPECS['lon'])
+    if lon_name is not None:
+        return lon_name
+    warnings.warn('longitude not found in dataset')
+
+
+def get_lat_name(ds):
+    '''
+    Get the latitude name in a `xarray.Dataset` or a `xarray.DataArray`
+
+    Parameters
+    ----------
+    ds: xarray.DataArray or xarray.Dataset
+
+    Returns
+    -------
+    str: Name of the xarray.DataArray
+    '''
+    lat_name = get_coord_name_from_specs(ds, CF_SPECS['lat'])
+    if lat_name is not None:
+        return lat_name
+    warnings.warn('latitude not found in dataset')
+
+
+def decode_cf(ds):
+    '''
+    Search for longitude and latitude and rename them
+
+    Parameters
+    ----------
+    ds: xarray.DataArray or xarray.Dataset
+
+    Returns
+    -------
+    ds: xarray.DataArray or xarray.Dataset
+    '''
+    # Longitude
+    lon_name = get_lon_name(ds)
+    if lon_name is not None:
+        ds = ds.rename({lon_name: 'lon'})
+        for suffix in ('_b', '_bounds'):
+            if lon_name+suffix in ds:
+                ds = ds.rename({lon_name+suffix: 'lon_b'})
+
+    # Latitude
+    lat_name = get_lat_name(ds)
+    if lat_name is not None:
+        ds = ds.rename({lat_name: 'lat'})
+        for suffix in ('_b', '_bounds'):
+            if lat_name+suffix in ds:
+                ds = ds.rename({lat_name+suffix: 'lat_b'})
+
+    return ds

--- a/xesmf/cf.py
+++ b/xesmf/cf.py
@@ -23,7 +23,6 @@ CF_SPECS = {
     }
 
 
-
 def get_coord_name_from_specs(ds, specs):
     '''
     Get the name of a `xarray.DataArray` according to search specifications
@@ -112,32 +111,48 @@ def get_lat_name(ds):
     warnings.warn('latitude not found in dataset')
 
 
-def decode_cf(ds):
+def decode_cf(ds, mapping=None):
     '''
     Search for longitude and latitude and rename them
 
     Parameters
     ----------
     ds: xarray.DataArray or xarray.Dataset
+    mapping: None or dict
+        When a `dict` is provided, it is filled with keys that are the new
+        names and values that are the old names, so that the output dataset
+        can have its coordinates be renamed back with
+        :meth:`~xarray.Dataset.rename`.
 
     Returns
     -------
     ds: xarray.DataArray or xarray.Dataset
     '''
+    # Suffixes for bounds
+    bsuffixes = ('_b', '_bounds', '_bnds')
+
     # Longitude
     lon_name = get_lon_name(ds)
-    if lon_name is not None:
+    if lon_name is not None and lon_name != 'lon':
         ds = ds.rename({lon_name: 'lon'})
-        for suffix in ('_b', '_bounds'):
+        if isinstance(mapping, dict):
+            mapping['lon'] = lon_name
+        for suffix in bsuffixes:
             if lon_name+suffix in ds:
                 ds = ds.rename({lon_name+suffix: 'lon_b'})
+                if isinstance(mapping, dict):
+                    mapping['lon_b'] = lon_name + suffix
 
     # Latitude
     lat_name = get_lat_name(ds)
-    if lat_name is not None:
+    if lat_name is not None and lat_name != 'lat':
         ds = ds.rename({lat_name: 'lat'})
-        for suffix in ('_b', '_bounds'):
+        if isinstance(mapping, dict):
+            mapping['lat'] = lat_name
+        for suffix in bsuffixes:
             if lat_name+suffix in ds:
                 ds = ds.rename({lat_name+suffix: 'lat_b'})
+                if isinstance(mapping, dict):
+                    mapping['lat_b'] = lat_name + suffix
 
     return ds

--- a/xesmf/tests/test_cf.py
+++ b/xesmf/tests/test_cf.py
@@ -44,19 +44,38 @@ def test_cf_get_lat_name(name, coord_specs):
     assert xecf.get_lat_name(da.assign_coords(**{name: coord_specs})) == name
 
 
+def test_get_bounds_name_from_coord_attribute():
+    da = coord_base.copy()
+    dab = xr.DataArray(np.arange(da.size+1, dtype='d'), dims='xb')
+    da.attrs.update(bounds='xb')
+    ds = xr.Dataset({'x': da, 'xb': dab}).set_coords('x')
+
+    assert xecf.get_bounds_name_from_coord(ds, 'x') == 'xb'
+
+
+def test_get_bounds_name_from_coord_name():
+    da = coord_base.copy()
+    dab = xr.DataArray(np.arange(da.size+1, dtype='d'), dims='x_b')
+    ds = xr.Dataset({'x': da, 'x_b': dab}).set_coords('x')
+
+    assert xecf.get_bounds_name_from_coord(ds, 'x') == 'x_b'
+
+
 def test_cf_decode_cf():
 
     yy, xx = np.mgrid[:3, :4].astype('d')
     yyb, xxb = np.mgrid[:4, :5] - .5
 
-    xx = xr.DataArray(xx, dims=['ny', 'nx'], attrs={'units': "degrees_east"})
+    xx = xr.DataArray(xx, dims=['ny', 'nx'],
+                      attrs={'units': "degrees_east",
+                             'bounds': "xx_boonds"})
     xxb = xr.DataArray(xxb, dims=['nyb', 'nxb'])
     yy = xr.DataArray(yy, dims=['ny', 'nx'])
     yyb = xr.DataArray(yyb, dims=['nyb', 'nxb'])
 
     ds = xr.Dataset({
         'xx': xx,
-        'xx_b': xxb,
+        'xx_boonds': xxb,
         'latitude': yy,
         'latitude_bounds': yyb})
     ds_decoded = xecf.decode_cf(ds)

--- a/xesmf/tests/test_cf.py
+++ b/xesmf/tests/test_cf.py
@@ -1,0 +1,63 @@
+import pytest
+import numpy as np
+import xarray as xr
+import xesmf.cf as xecf
+
+
+coord_base = xr.DataArray(np.arange(2), dims='d')
+da = xr.DataArray(np.ones(2), dims='d', name='temp')
+
+
+def test_cf_get_lon_name_warns():
+    with pytest.warns(UserWarning):
+        xecf.get_lon_name(da.to_dataset())
+
+
+@pytest.mark.parametrize("name,coord_specs", [
+    ('lon', coord_base),
+    ('longitude', coord_base),
+    ('x', ('d', coord_base, {'units': 'degrees_east'})),
+    ('x', ('d', coord_base, {'standard_name': 'longitude'})),
+    ('xu', ('d', coord_base, {'standard_name': 'longitude_at_U_location'})),
+    ('x', ('d', coord_base, {'axis': 'X'})),
+    ('x', ('d', coord_base, {'units': 'degrees_east', 'axis': 'Y'})),
+    ])
+def test_cf_get_lon_name(name, coord_specs):
+    assert xecf.get_lon_name(da.assign_coords(**{name: coord_specs})) == name
+
+
+def test_cf_get_lat_name_warns():
+    with pytest.warns(UserWarning):
+        xecf.get_lat_name(da.to_dataset())
+
+
+@pytest.mark.parametrize("name,coord_specs", [
+    ('lat', coord_base),
+    ('latitude', coord_base),
+    ('y', ('d', coord_base, {'units': 'degrees_north'})),
+    ('y', ('d', coord_base, {'standard_name': 'latitude'})),
+    ('yu', ('d', coord_base, {'standard_name': 'latitude_at_V_location'})),
+    ('y', ('d', coord_base, {'axis': 'Y'})),
+    ('y', ('d', coord_base, {'units': 'degrees_north', 'axis': 'X'})),
+    ])
+def test_cf_get_lat_name(name, coord_specs):
+    assert xecf.get_lat_name(da.assign_coords(**{name: coord_specs})) == name
+
+
+def test_cf_decode_cf():
+
+    yy, xx = np.mgrid[:3, :4].astype('d')
+    yyb, xxb = np.mgrid[:4, :5] - .5
+
+    xx = xr.DataArray(xx, dims=['ny', 'nx'], attrs={'units': "degrees_east"})
+    xxb = xr.DataArray(xxb, dims=['nyb', 'nxb'])
+    yy = xr.DataArray(yy, dims=['ny', 'nx'])
+    yyb = xr.DataArray(yyb, dims=['nyb', 'nxb'])
+
+    ds = xr.Dataset({
+        'xx': xx,
+        'xx_b': xxb,
+        'latitude': yy,
+        'latitude_bounds': yyb})
+    ds_decoded = xecf.decode_cf(ds)
+    assert sorted(list(ds_decoded)) == ['lat', 'lat_b', 'lon', 'lon_b']

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -260,3 +260,29 @@ def test_regrid_dataset():
 
     # clean-up
     regridder.clean_weight_file()
+
+
+def test_regrid_dataset_renamed_back():
+
+    # renaming
+    ds_out2 = ds_out.rename(lon='X', lat='Y', lon_b='X_b', lat_b='Y_bnds')
+    ds_out2.X.attrs['units'] = 'degrees_east'
+    ds_out2.Y.attrs['standard_name'] = 'latitude'
+    print(ds_out2.X.units)
+
+    regridder = xe.Regridder(ds_in, ds_out2, 'conservative')
+
+    ds_result = regridder(ds_in)
+
+    # compare with analytical solution
+    rel_err = (ds_out2['data_ref'] - ds_result['data'])/ds_out2['data_ref']
+    assert np.max(np.abs(rel_err)) < 0.05
+
+    # check that name are restored
+    assert 'X' in ds_result.coords
+    assert 'Y' in ds_result.coords
+    assert 'X_b' in ds_result.variables
+    assert 'Y_bnds' in ds_result.variables
+
+    # clean-up
+    regridder.clean_weight_file()


### PR DESCRIPTION
This PR adds some support for CF conventions to search for longitude and latitude in Datasets, and rename them to 'lon' and 'lat'. Bounds data arrays are also renamed if found.

A module named 'cf' was created for that and unitests were added.