### PR TITLE
Add support for custom coordinate names

### DIFF
--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -54,7 +54,7 @@ def is_latitude(var):
 
 def cf_lon_lat(ds):
     if isinstance(ds, xr.Dataset):
-        vars = ds.coords.values()
+        vars = ds.variables.values()  # Should this be restricted to coords ?
     else:
         vars = ds.values()
 
@@ -96,17 +96,16 @@ def get_lon_lat(ds, var_names=None):
     else:
         out = ds[var_names["lon"]], ds[var_names["lat"]]
 
-    print(out)
     return map(np.asarray, out)
 
 
 def get_lon_lat_bnds(ds, var_names=None):
     if var_names is None:
-        lon, lat = cf_lon_lat_bnds(ds)
-        if lon.ndim == 1:
-            out = map(cf_to_esm_bnds_1d, [lon, lat])
-        elif lon.ndim == 2:
-            out = map(cf_to_esm_bnds_2d, [lon, lat])
+        lon_bnds, lat_bnds = cf_lon_lat_bnds(ds)
+        if lon_bnds.ndim == 2:
+            out = map(cf_to_esm_bnds_1d, [lon_bnds, lat_bnds])
+        elif lon_bnds.ndim == 3:
+            out = map(cf_to_esm_bnds_2d, [lon_bnds, lat_bnds])
     else:
         out = ds[var_names["lon_b"]], ds[var_names["lat_b"]]
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -21,7 +21,7 @@ except ImportError:
 
 default_var_names = {"lat": "lat",
                      "lon": "lon",
-                     "lat_b": "lon_b",
+                     "lat_b": "lat_b",
                      "lon_b": "lon_b"}
 
 
@@ -59,14 +59,14 @@ def cf_lon_lat(ds):
         vars = ds.values()
 
     lon = list(filter(is_longitude, vars))
-    lat = list(filter(is_longitude, vars))
+    lat = list(filter(is_latitude, vars))
 
-    if lon == []:
+    if not lon:
         raise ValueError("No longitude coordinate found."
                          "Identify the longitude variable by setting its `long_name` attribute to `longitude`."
                          )
 
-    if lat == []:
+    if not lat:
         raise ValueError("No latitude coordinate found."
                          "Identify the latitude variable by setting its `long_name` attribute to `latitude`."
                          )
@@ -96,6 +96,7 @@ def get_lon_lat(ds, var_names=None):
     else:
         out = ds[var_names["lon"]], ds[var_names["lat"]]
 
+    print(out)
     return map(np.asarray, out)
 
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -151,9 +151,16 @@ def test_regrid_periodic_correct(vn):
 
 def ds_2d_to_1d(ds):
     ds_temp = ds.reset_coords()
-    ds_1d = xr.merge([ds_temp['lon'][0, :], ds_temp['lat'][:, 0]])
+    ds_1d = xr.merge([ds_temp['lon'][0, :],
+                      ds_temp['lat'][:, 0],
+                      ds_temp['lon_bnds'][0, :, :],
+                      ds_temp['lat_bnds'][:, 0, :]]
+                     )
     ds_1d.coords['lon'] = ds_1d['lon']
     ds_1d.coords['lat'] = ds_1d['lat']
+    ds_1d.coords['lon_bnds'] = ds_1d['lon_bnds']
+    ds_1d.coords['lat_bnds'] = ds_1d['lat_bnds']
+
     return ds_1d
 
 

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -102,7 +102,7 @@ def test_existing_weights(vn):
 
 def test_conservative_without_bounds():
     with pytest.raises(KeyError):
-        xe.Regridder(ds_in.drop_vars('lon_b'), ds_out, 'conservative')
+        xe.Regridder(ds_in.drop_vars('lon_b'), ds_out, 'conservative', var_names=dvn)
 
 
 def test_build_regridder_from_dict():
@@ -116,9 +116,10 @@ def test_build_regridder_from_dict():
     regridder.clean_weight_file()
 
 
-def test_regrid_periodic_wrong():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_periodic_wrong(vn):
     # not using periodic option
-    regridder = xe.Regridder(ds_in, ds_out, 'bilinear')
+    regridder = xe.Regridder(ds_in, ds_out, 'bilinear', var_names=vn)
 
     dr_out = regridder(ds_in['data'])  # xarray DataArray
 
@@ -130,8 +131,9 @@ def test_regrid_periodic_wrong():
     regridder.clean_weight_file()
 
 
-def test_regrid_periodic_correct():
-    regridder = xe.Regridder(ds_in, ds_out, 'bilinear', periodic=True)
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_periodic_correct(vn):
+    regridder = xe.Regridder(ds_in, ds_out, 'bilinear', periodic=True, var_names=vn)
 
     dr_out = regridder(ds_in['data'])
 
@@ -151,11 +153,12 @@ def ds_2d_to_1d(ds):
     return ds_1d
 
 
-def test_regrid_with_1d_grid():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_with_1d_grid(vn):
     ds_in_1d = ds_2d_to_1d(ds_in)
     ds_out_1d = ds_2d_to_1d(ds_out)
 
-    regridder = xe.Regridder(ds_in_1d, ds_out_1d, 'bilinear', periodic=True)
+    regridder = xe.Regridder(ds_in_1d, ds_out_1d, 'bilinear', periodic=True, var_names=vn)
 
     dr_out = regridder(ds_in['data'])
 
@@ -174,10 +177,11 @@ def test_regrid_with_1d_grid():
 # TODO: consolidate (regrid method, input data types) combination
 # using pytest fixtures and parameterization
 
-def test_regrid_dataarray():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray(vn):
     # xarray.DataArray containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative', var_names=vn)
 
     outdata = regridder(ds_in['data'].values)  # pure numpy array
     dr_out = regridder(ds_in['data'])  # xarray DataArray
@@ -209,10 +213,11 @@ def test_regrid_dataarray():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataarray_to_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray_to_locstream(vn):
     # xarray.DataArray containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True)
+    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True, var_names=vn)
 
     outdata = regridder(ds_in['data'].values)  # pure numpy array
     dr_out = regridder(ds_in['data'])  # xarray DataArray
@@ -227,10 +232,11 @@ def test_regrid_dataarray_to_locstream():
         regridder = xe.Regridder(ds_in, ds_locs, 'conservative', locstream_out=True)
 
 
-def test_regrid_dataarray_from_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray_from_locstream(vn):
     # xarray.DataArray containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True)
+    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True, var_names=vn)
 
     outdata = regridder(ds_locs['lat'].values)  # pure numpy array
     dr_out = regridder(ds_locs['lat'])  # xarray DataArray
@@ -249,10 +255,11 @@ def test_regrid_dataarray_from_locstream():
         regridder = xe.Regridder(ds_locs, ds_in, 'conservative', locstream_in=True)
 
 
-def test_regrid_dask():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dask(vn):
     # chunked dask array (no xarray metadata)
 
-    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative', var_names=vn)
 
     indata = ds_in_chunked['data4D'].data
     outdata = regridder(indata)
@@ -269,10 +276,11 @@ def test_regrid_dask():
     regridder.clean_weight_file()
 
 
-def test_regrid_dask_to_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dask_to_locstream(vn):
     # chunked dask array (no xarray metadata)
 
-    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True)
+    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True, var_names=vn)
 
     indata = ds_in_chunked['data4D'].data
     outdata = regridder(indata)
@@ -281,10 +289,11 @@ def test_regrid_dask_to_locstream():
     regridder.clean_weight_file()
 
 
-def test_regrid_dask_from_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dask_from_locstream(vn):
     # chunked dask array (no xarray metadata)
 
-    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True)
+    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True, var_names=vn)
 
     outdata = regridder(ds_locs['lat'].data)
 
@@ -292,10 +301,11 @@ def test_regrid_dask_from_locstream():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataarray_dask():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray_dask(vn):
     # xarray.DataArray containing chunked dask array
 
-    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative', var_names=vn)
 
     dr_in = ds_in_chunked['data4D']
     dr_out = regridder(dr_in)
@@ -318,10 +328,11 @@ def test_regrid_dataarray_dask():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataarray_dask_to_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray_dask_to_locstream(vn):
     # xarray.DataArray containing chunked dask array
 
-    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True)
+    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True, var_names=vn)
 
     dr_in = ds_in_chunked['data4D']
     dr_out = regridder(dr_in)
@@ -330,10 +341,11 @@ def test_regrid_dataarray_dask_to_locstream():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataarray_dask_from_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataarray_dask_from_locstream(vn):
     # xarray.DataArray containing chunked dask array
 
-    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True)
+    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True, var_names=vn)
 
     outdata = regridder(ds_locs['lat'])
 
@@ -341,10 +353,11 @@ def test_regrid_dataarray_dask_from_locstream():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataset():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataset(vn):
     # xarray.Dataset containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_in, ds_out, 'conservative')
+    regridder = xe.Regridder(ds_in, ds_out, 'conservative', var_names=vn)
 
     # `ds_out` already refers to output grid object
     # TODO: use more consistent variable namings across tests
@@ -372,34 +385,38 @@ def test_regrid_dataset():
     regridder.clean_weight_file()
 
 
-def test_regrid_dataset_to_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataset_to_locstream(vn):
     # xarray.Dataset containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True)
+    regridder = xe.Regridder(ds_in, ds_locs, 'bilinear', locstream_out=True, var_names=vn)
     ds_result = regridder(ds_in)
     # clean-up
     regridder.clean_weight_file()
 
 
-def test_regrid_dataset_from_locstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_regrid_dataset_from_locstream(vn):
     # xarray.Dataset containing in-memory numpy array
 
-    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True)
+    regridder = xe.Regridder(ds_locs, ds_in, 'nearest_s2d', locstream_in=True, var_names=vn)
     outdata = regridder(ds_locs)
     # clean-up
     regridder.clean_weight_file()
 
 
-def test_ds_to_ESMFlocstream():
+@pytest.mark.parametrize("vn", [dvn, None])
+def test_ds_to_ESMFlocstream(vn):
     import ESMF
     from xesmf.frontend import ds_to_ESMFlocstream
 
-    locstream, shape = ds_to_ESMFlocstream(ds_locs)
+    locstream, shape = ds_to_ESMFlocstream(ds_locs, var_names=vn)
     assert isinstance(locstream, ESMF.LocStream)
-    assert shape == (1,4,)
+    assert shape == (1, 4,)
     with pytest.raises(ValueError):
-        locstream, shape = ds_to_ESMFlocstream(ds_in)
+        locstream, shape = ds_to_ESMFlocstream(ds_in, var_names=vn)
+
     ds_bogus = ds_in.copy()
     ds_bogus['lon'] = ds_locs['lon']
     with pytest.raises(ValueError):
-        locstream, shape = ds_to_ESMFlocstream(ds_bogus)
+        locstream, shape = ds_to_ESMFlocstream(ds_bogus, var_names=vn)

--- a/xesmf/tests/test_frontend.py
+++ b/xesmf/tests/test_frontend.py
@@ -28,8 +28,12 @@ ds_out['data4D_ref'] = ds_in['time'] * ds_in['lev'] * ds_out['data_ref']
 ds_in_chunked = ds_in.chunk({'time': 3, 'lev': 2})
 
 ds_locs = xr.Dataset()
-ds_locs['lat'] = xr.DataArray(data=[-20, -10, 0, 10], dims=('locations',), attrs={"long_name": "latitude"})
-ds_locs['lon'] = xr.DataArray(data=[0, 5, 10, 15], dims=('locations',), attrs={"long_name": "longitude"})
+ds_locs['lat'] = xr.DataArray(data=[-20, -10, 0, 10],
+                              dims=('locations',),
+                              attrs={"long_name": "latitude", "units": "degrees_north"})
+ds_locs['lon'] = xr.DataArray(data=[0, 5, 10, 15],
+                              dims=('locations',),
+                              attrs={"long_name": "longitude", "units": "degrees_east"})
 
 
 def test_as_2d_mesh():

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -1,6 +1,9 @@
 import numpy as np
 import xesmf as xe
+import xarray as xr
 import pytest
+
+from . test_frontend import ds_in
 
 
 def test_grid_global():
@@ -35,3 +38,42 @@ def test_cf_bnds_2d():
     eb = xe.util.cf_to_esm_bnds_2d(ds['lat_bnds'])
     np.testing.assert_array_equal(eb, ds['lat_b'])
 
+
+def test_cf_lon_lat():
+    # Dataset
+    lon, lat = xe.util.cf_lon_lat(ds_in)
+    xr.testing.assert_equal(lon, ds_in["lon"])
+    xr.testing.assert_equal(lat, ds_in["lat"])
+
+    # DataArray
+    lon, lat = xe.util.cf_lon_lat(ds_in["data"])
+    xr.testing.assert_equal(lon, ds_in["lon"])
+    xr.testing.assert_equal(lat, ds_in["lat"])
+
+    # Dict
+    lon, lat = xe.util.cf_lon_lat(dict(ds_in["data"].coords))
+    xr.testing.assert_equal(lon, ds_in["lon"])
+    xr.testing.assert_equal(lat, ds_in["lat"])
+
+    # Missing attributes
+    ds_miss = ds_in.copy()
+    ds_miss.lon.attrs["long_name"] = ""
+    with pytest.raises(ValueError):
+        xe.util.cf_lon_lat(ds_miss)
+
+    ds_miss = ds_in.copy()
+    ds_miss.lat.attrs["long_name"] = ""
+    with pytest.raises(ValueError):
+        xe.util.cf_lon_lat(ds_miss)
+
+
+def test_cf_bnds():
+    ds_miss = ds_in.copy()
+    ds_miss.lat.attrs.pop("bounds")
+    with pytest.raises(ValueError):
+        xe.util.cf_bnds(ds_miss, ds_miss["lat"])
+
+    ds_miss = ds_in.copy()
+    ds_miss.lat.attrs["bounds"] = "kabong"
+    with pytest.raises(ValueError):
+        xe.util.cf_bnds(ds_miss, ds_miss["lat"])

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -3,7 +3,7 @@ import xesmf as xe
 import xarray as xr
 import pytest
 
-from . test_frontend import ds_in
+from . test_frontend import ds_in, ds_2d_to_1d
 
 
 def test_grid_global():
@@ -79,3 +79,19 @@ def test_cf_bnds():
     ds_miss.lat.attrs["bounds"] = "kabong"
     with pytest.raises(ValueError):
         xe.util.cf_bnds(ds_miss, ds_miss["lat"])
+
+
+def test_get_lon_lat_bnds():
+    ds2 = xe.util.grid_2d(0, 2, 1, 10, 11, 1)
+    ds1 = ds_2d_to_1d(ds2)
+
+    lon, lat = xe.util.get_lon_lat_bnds(ds2)
+    np.testing.assert_array_equal(lon.shape, np.array(ds2.lon.shape) + 1)
+    np.testing.assert_array_equal(lat.shape, np.array(ds2.lat.shape) + 1)
+
+    lon, lat = xe.util.get_lon_lat_bnds(ds1)
+    assert lon.shape[0] == ds1.lon.shape[0] + 1
+    assert lat.shape[0] == ds1.lat.shape[0] + 1
+
+
+

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -55,14 +55,16 @@ def test_cf_lon_lat():
     xr.testing.assert_equal(lon, ds_in["lon"])
     xr.testing.assert_equal(lat, ds_in["lat"])
 
-    # Missing attributes
+    # Missing attributes and standard name
     ds_miss = ds_in.copy()
     ds_miss.lon.attrs["units"] = ""
+    ds_miss.lon.attrs["standard_name"] = ""
     with pytest.raises(ValueError):
         xe.util.cf_lon_lat(ds_miss)
 
     ds_miss = ds_in.copy()
     ds_miss.lat.attrs["units"] = ""
+    ds_miss.lat.attrs["standard_name"] = ""
     with pytest.raises(ValueError):
         xe.util.cf_lon_lat(ds_miss)
 

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -1,3 +1,4 @@
+import numpy as np
 import xesmf as xe
 import pytest
 
@@ -19,3 +20,18 @@ def test_grid_global_bad_resolution():
 
     with pytest.warns(UserWarning):
         xe.util.grid_global(1.23, 1.5)
+
+
+def test_cf_bnds_1d():
+    xc, xb = xe.util._grid_1d(0, 2, 1)
+    cfb = xe.util._cf_bnds_1d(xb)
+    np.testing.assert_array_equal(cfb, [[0, 1], [1, 2]])
+    new_xb = xe.util.cf_to_esm_bnds_1d(cfb)
+    np.testing.assert_array_equal(new_xb, xb)
+
+
+def test_cf_bnds_2d():
+    ds = xe.util.grid_2d(0, 2, 1, 10, 11, 1)
+    eb = xe.util.cf_to_esm_bnds_2d(ds['lat_bnds'])
+    np.testing.assert_array_equal(eb, ds['lat_b'])
+

--- a/xesmf/tests/test_util.py
+++ b/xesmf/tests/test_util.py
@@ -57,12 +57,12 @@ def test_cf_lon_lat():
 
     # Missing attributes
     ds_miss = ds_in.copy()
-    ds_miss.lon.attrs["long_name"] = ""
+    ds_miss.lon.attrs["units"] = ""
     with pytest.raises(ValueError):
         xe.util.cf_lon_lat(ds_miss)
 
     ds_miss = ds_in.copy()
-    ds_miss.lat.attrs["long_name"] = ""
+    ds_miss.lat.attrs["units"] = ""
     with pytest.raises(ValueError):
         xe.util.cf_lon_lat(ds_miss)
 

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -237,7 +237,8 @@ def has_standard_name_of_longitude(var):
       True if variable's `standard_name` attribute starts with longitude.
     """
     key = "standard_name"
-    return var.attrs.get(key) == "longitude"
+    value = var.attrs.get(key, "")
+    return value == "longitude" or value.startswith("longitude_at_")
 
 
 def has_standard_name_of_latitude(var):
@@ -254,7 +255,8 @@ def has_standard_name_of_latitude(var):
       True if variable's `standard_name` attribute starts with latitude.
     """
     key = "standard_name"
-    return var.attrs.get(key) == "latitude"
+    value = var.attrs.get(key, "")
+    return value == "latitude" or value.startswith("latitude_at_")
 
 
 def has_units_of_longitude(var):

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -29,7 +29,7 @@ def _grid_1d(start_b, end_b, step):
 
 
 def _cf_bnds_1d(bounds):
-    """Return a CF-compliant coordinate boundaries.
+    """Return CF-compliant coordinate bounds.
 
     Parameters
     ----------
@@ -39,13 +39,13 @@ def _cf_bnds_1d(bounds):
     Returns
     -------
     array (n, 2)
-      Left [:,0] and right [:1] boundaries.
+      Left [:,0] and right [:1] bounds.
     """
     return np.vstack((bounds[:-1], bounds[1:])).T
 
 
 def _cf_bnds_2d(bounds):
-    """Return a CF-compliant coordinate boundaries.
+    """Return CF-compliant coordinate bounds.
 
     Parameters
     ----------
@@ -61,13 +61,14 @@ def _cf_bnds_2d(bounds):
 
 
 def cf_to_esm_bnds_1d(vertices):
-    """Convert 2D CF-compliant boundaries to 1D ESM boundaries."""
+    """Convert 2D CF-compliant bounds to 1D ESM boundaries."""
     v = vertices
     return np.concatenate((v[:, 0], v[-1:, 1]))
 
 
+# TODO: This is probably not true in general, and depends on the convention used, starting point, clockwise, etc.
 def cf_to_esm_bnds_2d(vertices):
-    """Convert 3D CF-compliant boundaries to 2D ESM boundaries."""
+    """Convert 3D CF-compliant bounds to 2D ESM boundaries."""
     v = vertices
     tl = v[:, :, 0]
     bl = v[-1:, :, 1]
@@ -147,3 +148,179 @@ def grid_global(d_lon, d_lat):
                       'might not cover the globe uniformally'.format(d_lat))
 
     return grid_2d(-180, 180, d_lon, -90, 90, d_lat)
+
+
+def is_longitude(var):
+    """Return True if variable is a longitude.
+
+    A variable is considered a longitude if its `long_name` attribute is 'longitude'.
+
+    Parameters
+    ----------
+    var: xr.Variable
+      Coordinate variable.
+
+    Return
+    ------
+    bool
+      True if variable is a longitude.
+
+    Example
+    -------
+    >>> # Identify the longitude coordinate in a dataset.
+    >>> lon = next(filter(is_longitude, ds.coords))
+    """
+    return var.attrs.get("long_name") == "longitude"
+
+
+def is_latitude(var):
+    """Return True if variable is a latitude.
+
+    A variable is considered a latitude if its `long_name` attribute is 'latitude'.
+
+    Parameters
+    ----------
+    var: xr.Variable
+      Coordinate variable.
+
+    Return
+    ------
+    bool
+      True if variable is a latitude.
+    """
+    return var.attrs.get("long_name") == "latitude"
+
+
+def cf_lon_lat(ds):
+    """Return longitude and latitude.
+
+    Identify the longitude and latitude coordinates based on the value of the `long_name` attribute.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+      Dataset storing coordinate information.
+
+    Return
+    ------
+    xr.DataArray, xr.DataArray
+      Longitude and latitude coordinates.
+    """
+    if isinstance(ds, xr.Dataset):
+        x = list(ds.coords.values()) + list(ds.data_vars.values())
+    elif isinstance(ds, xr.DataArray):
+        x = ds.coords.values()
+    else:  # dict
+        x = ds.values()
+
+    lon = list(filter(is_longitude, x))
+    lat = list(filter(is_latitude, x))
+
+    msg = "No {0} coordinate found." \
+          "Identify the longitude variable by setting its `long_name` attribute to `{0}`."
+
+    if not lon:
+        raise ValueError(msg.format("longitude"))
+
+    if not lat:
+        raise ValueError(msg.format("latitude"))
+
+    return lon[0], lat[0]
+
+
+def cf_bnds(ds, coord):
+    """Return the coordinate boundaries for a given coordinate.
+
+    Identify the boundaries based on the value of the `bounds` attribute of the coordinate.
+    If coordinate has no `bounds` attribute, raise an error.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+      Dataset storing coordinate information.
+    coord: xr.DataArray
+      Coordinate whose boundaries should be returned.
+
+    Return
+    ------
+    xr.DataArray
+      The coordinate boundaries.
+    """
+    key = coord.attrs.get("bounds")
+    if key is None:
+        raise ValueError(f"No bounds found for {coord.name}."
+                         "Identify the longitude bounds by setting the `bounds` attribute of the longitude variable "
+                         "to an existing variable name.")
+    if key not in ds:
+        raise ValueError(f"The variable {key} identified as the bounds for {coord.name} is not in this dataset.")
+
+    return ds[key]
+
+
+def cf_lon_lat_bnds(ds):
+    """Return longitude and latitude boundaries.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+      Dataset storing coordinate information.
+
+    Return
+    ------
+    xr.DataArray, xr.DataArray
+      Longitude and latitude boundaries.
+    """
+    lon, lat = cf_lon_lat(ds)
+    return cf_bnds(ds ,lon), cf_bnds(ds, lat)
+
+
+def get_lon_lat(ds, var_names=None):
+    """Return longitude and latitude coordinates.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+      Dataset storing coordinate information.
+    var_names: dict
+      Dictionary with keys `lon` and `lat` identifying the name of the variables storing longitude and latitude
+      coordinates respectively.
+
+    Return
+    ------
+    np.ndarray, np.ndarray
+      Longitude and latitude arrays.
+    """
+    if var_names is None:
+        out = cf_lon_lat(ds)
+    else:
+        out = ds[var_names["lon"]], ds[var_names["lat"]]
+
+    return map(np.asarray, out)
+
+
+def get_lon_lat_bnds(ds, var_names=None):
+    """Return longitude and latitude coordinate boundaries.
+
+    Parameters
+    ----------
+    ds: xr.Dataset
+      Dataset storing coordinate information.
+    var_names: dict
+      Dictionary with keys `lon_b` and `lat_b` identifying the name of the variables storing longitude and latitude
+      coordinate boundaries respectively.
+
+    Return
+    ------
+    np.ndarray, np.ndarray
+      Longitude and latitude boundary arrays.
+    """
+    if var_names is None:
+        lon_bnds, lat_bnds = cf_lon_lat_bnds(ds)
+        if lon_bnds.ndim == 2:
+            out = map(cf_to_esm_bnds_1d, [lon_bnds, lat_bnds])
+        elif lon_bnds.ndim == 3:
+            out = map(cf_to_esm_bnds_2d, [lon_bnds, lat_bnds])
+    else:
+        out = ds[var_names["lon_b"]], ds[var_names["lat_b"]]
+
+    return map(np.asarray, out)

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -28,6 +28,55 @@ def _grid_1d(start_b, end_b, step):
     return centers, bounds
 
 
+def _cf_bnds_1d(bounds):
+    """Return a CF-compliant coordinate boundaries.
+
+    Parameters
+    ----------
+    bounds: array (n+1)
+      Array with ordered left and right boundaries.
+
+    Returns
+    -------
+    array (n, 2)
+      Left [:,0] and right [:1] boundaries.
+    """
+    return np.vstack((bounds[:-1], bounds[1:])).T
+
+
+def _cf_bnds_2d(bounds):
+    """Return a CF-compliant coordinate boundaries.
+
+    Parameters
+    ----------
+    bounds: array (n+1, m+1)
+      Array with ordered left and right boundaries.
+
+    Returns
+    -------
+    array (n, m, 4)
+      Counter
+    """
+    return np.dstack((bounds[:-1, :-1], bounds[1:, :-1], bounds[1:, 1:], bounds[:-1, 1:]))
+
+
+def cf_to_esm_bnds_1d(vertices):
+    """Convert 2D CF-compliant boundaries to 1D ESM boundaries."""
+    v = vertices
+    return np.concatenate((v[:, 0], v[-1:, 1]))
+
+
+def cf_to_esm_bnds_2d(vertices):
+    """Convert 3D CF-compliant boundaries to 2D ESM boundaries."""
+    v = vertices
+    tl = v[:, :, 0]
+    bl = v[-1:, :, 1]
+    tr = v[:, -1:, 3]
+    br = v[-1:, -1:, 2]
+    return np.block([[tl, tr],
+                     [bl, br]])
+
+
 def grid_2d(lon0_b, lon1_b, d_lon,
             lat0_b, lat1_b, d_lat):
     '''
@@ -59,10 +108,12 @@ def grid_2d(lon0_b, lon1_b, d_lon,
     lon, lat = np.meshgrid(lon_1d, lat_1d)
     lon_b, lat_b = np.meshgrid(lon_b_1d, lat_b_1d)
 
-    ds = xr.Dataset(coords={'lon': (['y', 'x'], lon),
-                            'lat': (['y', 'x'], lat),
+    ds = xr.Dataset(coords={'lon': (['y', 'x'], lon, {"long_name": "longitude", "bounds": "lon_bnds"}),
+                            'lat': (['y', 'x'], lat, {"long_name": "latitude", "bounds": "lat_bnds"}),
                             'lon_b': (['y_b', 'x_b'], lon_b),
-                            'lat_b': (['y_b', 'x_b'], lat_b)
+                            'lat_b': (['y_b', 'x_b'], lat_b),
+                            'lon_bnds': (['y', 'x', 'nv'], _cf_bnds_2d(lon_b)),
+                            'lat_bnds': (['y', 'x', 'nv'], _cf_bnds_2d(lat_b))
                             }
                     )
 

--- a/xesmf/util.py
+++ b/xesmf/util.py
@@ -109,8 +109,10 @@ def grid_2d(lon0_b, lon1_b, d_lon,
     lon, lat = np.meshgrid(lon_1d, lat_1d)
     lon_b, lat_b = np.meshgrid(lon_b_1d, lat_b_1d)
 
-    ds = xr.Dataset(coords={'lon': (['y', 'x'], lon, {"long_name": "longitude", "bounds": "lon_bnds"}),
-                            'lat': (['y', 'x'], lat, {"long_name": "latitude", "bounds": "lat_bnds"}),
+    ds = xr.Dataset(coords={'lon': (['y', 'x'], lon,
+                                    {"standard_name": "longitude", "bounds": "lon_bnds",  "units":"degrees_east"}),
+                            'lat': (['y', 'x'], lat,
+                                    {"standard_name": "latitude", "bounds": "lat_bnds", "units": "degrees_north"}),
                             'lon_b': (['y_b', 'x_b'], lon_b),
                             'lat_b': (['y_b', 'x_b'], lat_b),
                             'lon_bnds': (['y', 'x', 'nv'], _cf_bnds_2d(lon_b)),
@@ -153,7 +155,7 @@ def grid_global(d_lon, d_lat):
 def is_longitude(var):
     """Return True if variable is a longitude.
 
-    A variable is considered a longitude if its `long_name` attribute is 'longitude'.
+    A variable is considered a longitude if its `units` are 'degrees_east' or a synonym.
 
     Parameters
     ----------
@@ -170,13 +172,13 @@ def is_longitude(var):
     >>> # Identify the longitude coordinate in a dataset.
     >>> lon = next(filter(is_longitude, ds.coords))
     """
-    return var.attrs.get("long_name") == "longitude"
+    return has_units_of_longitude(var)
 
 
 def is_latitude(var):
     """Return True if variable is a latitude.
 
-    A variable is considered a latitude if its `long_name` attribute is 'latitude'.
+    A variable is considered a latitude if its `units` are 'degrees_north' or a synonym.
 
     Parameters
     ----------
@@ -188,7 +190,25 @@ def is_latitude(var):
     bool
       True if variable is a latitude.
     """
-    return var.attrs.get("long_name") == "latitude"
+    return has_units_of_latitude(var)
+
+
+def has_name_of_longitude(var):
+    key = "standard_name"
+    return var.attrs.get(key) == "longitude"
+
+
+def has_name_of_latitude(var):
+    key = "standard_name"
+    return var.attrs.get(key) == "latitude"
+
+
+def has_units_of_longitude(var):
+    return var.attrs.get("units") in ("degrees_east", "degree_east", "degree_E", "degrees_E", "degreeE", "degreesE")
+
+
+def has_units_of_latitude(var):
+    return var.attrs.get("units") in ("degrees_north", "degree_north", "degree_N", "degrees_N", "degreeN", "degreesN")
 
 
 def cf_lon_lat(ds):


### PR DESCRIPTION
As proposed in #74, this PR uses a dictionary of variable names to indicate which variables hold latitude and longitude coordinates and bounds. If this dictionary is not given, the code uses very basic heuristics based on the CF-Convention to find the coordinates and their bounds. The bounds are then converted into the format required by ESMF. 

Note that the conversion from vertices (nx, ny, 4) is probably wrong and needs additional work and testing. 
