### PR TITLE
Extrapolation and masking

### DIFF
--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -276,7 +276,7 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
         esmf_extrap_method = extrap_dict[extrap]
     except:
         raise ValueError('method should be chosen from '
-                         '{}'.format(list(method_dict.keys())))
+                         '{}'.format(list(extrap_dict.keys())))
 
     # until ESMPy updates ESMP_FieldRegridStoreFile, extrapolation is not possible
     # if files are written on disk

--- a/xesmf/backend.py
+++ b/xesmf/backend.py
@@ -215,7 +215,8 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
         Offline weight file. **Require ESMPy 7.1.0.dev38 or newer.**
         With the weights available, we can use Scipy's sparse matrix
         mulplication to apply weights, which is faster and more Pythonic
-        than ESMPy's online regridding.
+        than ESMPy's online regridding. If None, weights are stored in
+        memory only.
 
     extra_dims : a list of integers, optional
         Extra dimensions (e.g. time or levels) in the data field
@@ -277,7 +278,8 @@ def esmf_regrid_build(sourcegrid, destgrid, method,
     regrid = ESMF.Regrid(sourcefield, destfield, filename=filename,
                          regrid_method=esmf_regrid_method,
                          unmapped_action=ESMF.UnmappedAction.IGNORE,
-                         ignore_degenerate=ignore_degenerate)
+                         ignore_degenerate=ignore_degenerate,
+                         factors=True)
 
     return regrid
 

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -104,7 +104,7 @@ def ds_to_ESMFlocstream(ds):
 
 class Regridder(object):
     def __init__(self, ds_in, ds_out, method, periodic=False,
-                 filename=None, reuse_weights=False, ignore_degenerate=None,
+                 weights=None, ignore_degenerate=None,
                  locstream_in=False, locstream_out=False):
         """
         Make xESMF regridder
@@ -134,16 +134,13 @@ class Regridder(object):
             Only useful for global grids with non-conservative regridding.
             Will be forced to False for conservative regridding.
 
-        filename : str, optional
-            Name for the weight file. The default naming scheme is::
-
-                {method}_{Ny_in}x{Nx_in}_{Ny_out}x{Nx_out}.nc
-
-            e.g. bilinear_400x600_300x400.nc
-
-        reuse_weights : bool, optional
-            Whether to read existing weight file to save computing time.
-            False by default (i.e. re-compute, not reuse).
+        weights : None, coo_matrix, dict, str, Dataset, Path,
+            Regridding weights, stored as
+              - a scipy.sparse COO matrix,
+              - a dictionary with keys `row_dst`, `col_src` and `weights`,
+              - an xarray Dataset with data variables `col`, `row` and `S`,
+              - or a path to a netCDF file created by ESMF.
+            If None, compute the weights.
 
         ignore_degenerate : bool, optional
             If False (default), raise error if grids contain degenerated cells
@@ -170,7 +167,6 @@ class Regridder(object):
 
         self.method = method
         self.periodic = periodic
-        self.reuse_weights = reuse_weights
         self.ignore_degenerate = ignore_degenerate
         self.locstream_in = locstream_in
         self.locstream_out = locstream_out
@@ -226,14 +222,11 @@ class Regridder(object):
         self.n_in = shape_in[0] * shape_in[1]
         self.n_out = shape_out[0] * shape_out[1]
 
-        if filename is None:
-            self.filename = self._get_default_filename()
-        else:
-            self.filename = filename
+        if weights is None:
+            weights = self._compute_weights()  # Dictionary of weights
 
-        # get weight matrix
-        self._write_weight_file()
-        self.weights = read_weights(self.filename, self.n_in, self.n_out)
+        # Convert weights, whatever their format, to a sparse coo matrix
+        self.weights = read_weights(weights, self.n_in, self.n_out)
 
     @property
     def A(self):
@@ -261,49 +254,22 @@ class Regridder(object):
 
         return filename
 
-    def _write_weight_file(self):
-
-        if os.path.exists(self.filename):
-            if self.reuse_weights:
-                print('Reuse existing file: {}'.format(self.filename))
-                return  # do not compute it again, just read it
-            else:
-                print('Overwrite existing file: {} \n'.format(self.filename),
-                      'You can set reuse_weights=True to save computing time.')
-                os.remove(self.filename)
-        else:
-            print('Create weight file: {}'.format(self.filename))
-
+    def _compute_weights(self):
         regrid = esmf_regrid_build(self._grid_in, self._grid_out, self.method,
-                                   filename=self.filename,
                                    ignore_degenerate=self.ignore_degenerate)
+
+        w = regrid.get_weights_dict(deep_copy=True)
         esmf_regrid_finalize(regrid)  # only need weights, not regrid object
-
-    def clean_weight_file(self):
-        """
-        Remove the offline weight file on disk.
-
-        To save the time on re-computing weights, you can just keep the file,
-        and set "reuse_weights=True" when initializing the regridder next time.
-        """
-        if os.path.exists(self.filename):
-            print("Remove file {}".format(self.filename))
-            os.remove(self.filename)
-        else:
-            print("File {} is already removed.".format(self.filename))
+        return w
 
     def __repr__(self):
         info = ('xESMF Regridder \n'
                 'Regridding algorithm:       {} \n'
-                'Weight filename:            {} \n'
-                'Reuse pre-computed weights? {} \n'
                 'Input grid shape:           {} \n'
                 'Output grid shape:          {} \n'
                 'Output grid dimension name: {} \n'
                 'Periodic in longitude?      {}'
                 .format(self.method,
-                        self.filename,
-                        self.reuse_weights,
                         self.shape_in,
                         self.shape_out,
                         self.out_horiz_dims,
@@ -509,3 +475,13 @@ class Regridder(object):
             ds_out = ds_out.squeeze(dim='dummy')
 
         return ds_out
+
+    def to_netcdf(self, filename=None):
+        '''Save weights to disk as a netCDF file.'''
+        if filename is None:
+            filename = self._get_default_filename()
+        w = self.weights
+        ds = xr.Dataset({"S": w.data, "col": w.col + 1, "row": w.row + 1})
+        ds.to_netcdf(filename)
+        return filename
+

--- a/xesmf/frontend.py
+++ b/xesmf/frontend.py
@@ -62,6 +62,11 @@ def ds_to_ESMFgrid(ds, need_bounds=False, periodic=None, append=None):
 
     # tranpose the arrays so they become Fortran-ordered
     grid = esmf_grid(lon.T, lat.T, periodic=periodic)
+    # detect ds["mask"] and add it to the grid
+    if 'mask' in ds.data_vars:
+        import ESMF
+        grid.add_item(ESMF.GridItem.MASK, staggerloc=ESMF.StaggerLoc.CENTER)
+        grid.mask[0][...] = np.asarray(ds['mask']).T
 
     if need_bounds:
         lon_b = np.asarray(ds['lon_b'])
@@ -104,6 +109,7 @@ def ds_to_ESMFlocstream(ds):
 
 class Regridder(object):
     def __init__(self, ds_in, ds_out, method, periodic=False,
+                 extrap=None, extrap_exp=None, extrap_num_pnts=None,
                  weights=None, ignore_degenerate=None,
                  locstream_in=False, locstream_out=False):
         """
@@ -113,8 +119,8 @@ class Regridder(object):
         ----------
         ds_in, ds_out : xarray DataSet, or dictionary
             Contain input and output grid coordinates. Look for variables
-            ``lon``, ``lat``, and optionally ``lon_b``, ``lat_b`` for
-            conservative method.
+            ``lon``, ``lat``, optionally ``lon_b``, ``lat_b`` for
+            conservative method, and ``mask``. Use 0 to identify cells to mask.
 
             Shape can be 1D (n_lon,) and (n_lat,) for rectilinear grids,
             or 2D (n_y, n_x) for general curvilinear grids.
@@ -133,6 +139,20 @@ class Regridder(object):
             Periodic in longitude? Default to False.
             Only useful for global grids with non-conservative regridding.
             Will be forced to False for conservative regridding.
+
+        extrap : str, optional
+            Extrapolation method. Options are
+
+            - 'inverse_dist'
+            - 'nearest_s2d'
+
+        extrap_exp : float, optional
+            The exponent to raise the distance to when calculating weights for the
+            extrapolation method. If none are specified, defaults to 2.0
+
+        extrap_num_pnts : int, optional
+            The number of source points to use for the extrapolation methods
+            that use more than one source point. If none are specified, defaults to 8
 
         weights : None, coo_matrix, dict, str, Dataset, Path,
             Regridding weights, stored as
@@ -167,6 +187,9 @@ class Regridder(object):
 
         self.method = method
         self.periodic = periodic
+        self.extrap = extrap
+        self.extrap_exp = extrap_exp
+        self.extrap_num_pnts = extrap_num_pnts
         self.ignore_degenerate = ignore_degenerate
         self.locstream_in = locstream_in
         self.locstream_out = locstream_out
@@ -256,6 +279,8 @@ class Regridder(object):
 
     def _compute_weights(self):
         regrid = esmf_regrid_build(self._grid_in, self._grid_out, self.method,
+                                   extrap = self.extrap, extrap_exp = self.extrap_exp,
+                                   extrap_num_pnts = self.extrap_num_pnts,
                                    ignore_degenerate=self.ignore_degenerate)
 
         w = regrid.get_weights_dict(deep_copy=True)

--- a/xesmf/tests/test_backend.py
+++ b/xesmf/tests/test_backend.py
@@ -112,6 +112,22 @@ def test_esmf_build_bilinear():
     esmf_regrid_finalize(regrid)
 
 
+def test_esmf_extrapolation():
+
+    grid_in = esmf_grid(lon_in.T, lat_in.T)
+    grid_out = esmf_grid(lon_out.T, lat_out.T)
+
+    regrid = esmf_regrid_build(grid_in, grid_out, 'bilinear')
+    data_out_esmpy = esmf_regrid_apply(regrid, data_in.T).T
+    # without extrapolation, the first and last lines/columns = 0
+    assert data_out_esmpy[0, 0] == 0
+
+    regrid = esmf_regrid_build(grid_in, grid_out, 'bilinear', extrap='inverse_dist', extrap_num_pnts=3, extrap_exp=1)
+    data_out_esmpy = esmf_regrid_apply(regrid, data_in.T).T
+    # the 3 closest points in data_in are 2.010, 2.005, and 1.992. The result should be roughly equal to 2.0
+    assert np.round(data_out_esmpy[0, 0], 1) == 2.0
+
+
 def test_regrid():
 
     # use conservative regridding as an example,


### PR DESCRIPTION
As discussed in Issue #93 (and earlier in #22), this adds the extrapolation functionalities of ESMPy 8.0.0 to xESMF. I also included masking functionalities that are compatible with ESMPy grids.

The changes are built on top of PR #91, since ESMP_FieldRegridStoreFile is outdated ("deprecated" even, based on a comment in the code) and does not include the new extrapolation functionalities. With #91, weights are kept in memory and the call to ESMF is instead made with ESMP_FieldRegridStore, which is up to date.

Masking is based on an automatic detection of a "mask" DataArray in the dataset.